### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/R/share/texmf/tex/latex/jss.cls
+++ b/R/share/texmf/tex/latex/jss.cls
@@ -236,7 +236,7 @@
     {\@Month{} \@Year, Volume~\@Volume, \@Seriesname~\@Issue}
     \hfill
     \@Firstdate\\ \nopagebreak
-    {\href{http://dx.doi.org/\@DOI}{\tt doi:\@DOI}}
+    {\href{https://doi.org/\@DOI}{\tt doi:\@DOI}}
     \hfill
     \@Seconddate  \nopagebreak
     \vspace{.3\baselineskip}
@@ -260,7 +260,7 @@
    {\fontfamily{pzc} \fontsize{28}{32} \selectfont Journal of Statistical Software}
    \vfill
    {\it \small \@Month{} \@Year, Volume~\@Volume, \@Seriesname~\@Issue.%
-            \hfill \href{http://dx.doi.org/\@DOI}{doi:\,\@DOI}}}\\[0.1cm]
+            \hfill \href{https://doi.org/\@DOI}{doi:\,\@DOI}}}\\[0.1cm]
      \hrule height 3pt}}
 \if@review
   \renewcommand{\maketitle}{
@@ -479,7 +479,7 @@
   \newcommand\@doi[1]{doi:\discretionary{}{}{}#1}\else
   \newcommand\@doi{doi:\discretionary{}{}{}\begingroup
 \urlstyle{tt}\Url}\fi
-\newcommand{\doi}[1]{\href{http://dx.doi.org/#1}{\normalfont\texttt{\@doi{#1}}}}
+\newcommand{\doi}[1]{\href{https://doi.org/#1}{\normalfont\texttt{\@doi{#1}}}}
 \newcommand{\E}{\mathsf{E}}
 \newcommand{\VAR}{\mathsf{VAR}}
 \newcommand{\COV}{\mathsf{COV}}

--- a/R/src/library/stats/man/HoltWinters.Rd
+++ b/R/src/library/stats/man/HoltWinters.Rd
@@ -109,7 +109,7 @@ HoltWinters(x, alpha = NULL, beta = NULL, gamma = NULL,
   C. C. Holt (1957)
   Forecasting seasonals and trends by exponentially weighted moving averages,
   \emph{ONR Research Memorandum, Carnegie Institute of Technology} \bold{52}.
-  (reprint at \url{http://dx.doi.org/10.1016/j.ijforecast.2003.09.015}).
+  (reprint at \url{https://doi.org/10.1016/j.ijforecast.2003.09.015}).
 
   P. R. Winters (1960).
   Forecasting sales by exponentially weighted moving averages.

--- a/R/src/library/tools/R/RdHelpers.R
+++ b/R/src/library/tools/R/RdHelpers.R
@@ -122,11 +122,11 @@ function(x)
     y <- gsub("/", "\\\\out{\\\\slash{}}", gsub("-", "\\\\out{\\\\-}", x))
 
     sprintf("\\ifelse{text}{%s}{\\ifelse{latex}{%s}{%s}}",
-            sprintf("doi: %s (URL: http://doi.org/%s)",
+            sprintf("doi: %s (URL: https://doi.org/%s)",
                     x, x),
-            sprintf("doi:\\out{\\nobreakspace{}}\\href{http://doi.org/%s}{%s}",
+            sprintf("doi:\\out{\\nobreakspace{}}\\href{https://doi.org/%s}{%s}",
                     x, y),
-            sprintf("doi: \\href{http://doi.org/%s}{%s}",
+            sprintf("doi: \\href{https://doi.org/%s}{%s}",
                     x, x)
             )
 }

--- a/R/src/library/tools/R/doitools.R
+++ b/R/src/library/tools/R/doitools.R
@@ -150,7 +150,7 @@ function(db, verbose = FALSE)
     }
 
     .check <- function(d) {
-        u <- paste0("http://doi.org/", d)
+        u <- paste0("https://doi.org/", d)
         ## Do we need to percent encode parts of the DOI name?
         h <- .fetch(u, d)
         if(inherits(h, "error")) {
@@ -162,7 +162,7 @@ function(db, verbose = FALSE)
         }
 
         ## Similar to URLs, see e.g.
-        ##   curl -I -L http://doi.org/10.1016/j.csda.2009.12.005
+        ##   curl -I -L https://doi.org/10.1016/j.csda.2009.12.005
         ## (As of 2016-12, this actually gives 400 Bad Request.)
         if(any(grepl("301 Moved Permanently", h, useBytes = TRUE))) {
             ind <- grep("^[Ll]ocation: ", h, useBytes = TRUE)

--- a/R/src/library/tools/R/toHTML.R
+++ b/R/src/library/tools/R/toHTML.R
@@ -310,12 +310,12 @@ function(x, header = TRUE, ...)
                                                 urlify,
                                                 2L)
             s <- .gsub_with_transformed_matches("&lt;(DOI|doi):[[:space:]]*([^<[:space:]]+[[:alnum:]])&gt;",
-                                                "&lt;<a href=\"http://dx.doi.org/%s\">doi:\\2</a>&gt;",
+                                                "&lt;<a href=\"https://doi.org/%s\">doi:\\2</a>&gt;",
                                                 s,
                                                 urlify,
                                                 2L)
             s <- .gsub_with_transformed_matches("[^>\"](DOI|doi):[[:space:]]*([^<[:space:]]+[[:alnum:]])",
-                                                "&lt;<a href=\"http://dx.doi.org/%s\">doi:\\2</a>&gt;",
+                                                "&lt;<a href=\"https://doi.org/%s\">doi:\\2</a>&gt;",
                                                 s,
                                                 urlify,
                                                 2L)

--- a/R/src/library/tools/R/utils.R
+++ b/R/src/library/tools/R/utils.R
@@ -591,7 +591,7 @@ function(val) {
 .canonicalize_doi <-
 function(x)
 {
-    x <- sub("^((doi|DOI):)?[[:space:]]*http://(dx[.])?doi[.]org/", "",
+    x <- sub("^((doi|DOI):)?[[:space:]]*https?://(dx[.])?doi[.]org/", "",
              x)
     sub("^(doi|DOI):", "", x)
 }

--- a/Recommended/Matrix/man/condest.Rd
+++ b/Recommended/Matrix/man/condest.Rd
@@ -66,7 +66,7 @@ onenormest(A, t = min(n, 5), A.x, At.x, n,
   A Block Algorithm for Matrix 1-Norm Estimation, with an Application to 1-Norm
   Pseudospectra.
   \emph{SIAM J. Matrix Anal. Appl.} \bold{21}, 4, 1185--1201.
-  \url{http://dx.doi.org/10.1137/S0895479899356080}
+  \url{https://doi.org/10.1137/S0895479899356080}
   %% and \url{http://citeseer.ist.psu.edu/223007.html}
 
   William W. Hager (1984).

--- a/Recommended/cluster/man/pam.Rd
+++ b/Recommended/cluster/man/pam.Rd
@@ -148,7 +148,7 @@ pam(x, k, diss = inherits(x, "dist"), metric = "euclidean",
   Clustering rules: A comparison of partitioning and hierarchical
   clustering algorithms;
   \emph{Journal of Mathematical Modelling and Algorithms} \bold{5},
-  475--504 (\url{http://dx.doi.org/10.1007/s10852-005-9022-1}).
+  475--504 (\url{https://doi.org/10.1007/s10852-005-9022-1}).
 
 }
 \seealso{

--- a/Recommended/mgcv/man/Tweedie.Rd
+++ b/Recommended/mgcv/man/Tweedie.Rd
@@ -77,7 +77,7 @@ Tweedie, M. C. K. (1984). An index which distinguishes between
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/coxph.Rd
+++ b/Recommended/mgcv/man/coxph.Rd
@@ -56,7 +56,7 @@ Klein, J.P and Moeschberger, M.L. (2003) Survival Analysis: Techniques for
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 }
 
 \seealso{\code{\link{cox.pht}}}

--- a/Recommended/mgcv/man/family.mgcv.Rd
+++ b/Recommended/mgcv/man/family.mgcv.Rd
@@ -46,7 +46,7 @@ given potential presence is modelled with a second linear predictor.
 \references{Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 }
 
 

--- a/Recommended/mgcv/man/gam.Rd
+++ b/Recommended/mgcv/man/gam.Rd
@@ -280,7 +280,7 @@ Key References on this implementation:
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models (with discussion).
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 Wood, S.N. (2011) Fast stable restricted maximum likelihood 
 and marginal likelihood estimation of semiparametric generalized linear 

--- a/Recommended/mgcv/man/gam.convergence.Rd
+++ b/Recommended/mgcv/man/gam.convergence.Rd
@@ -65,7 +65,7 @@ Key References on this implementation:
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models (with discussion).
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 Wood, S.N. (2011) Fast stable restricted maximum likelihood 
 and marginal likelihood estimation of semiparametric generalized linear 

--- a/Recommended/mgcv/man/gaulss.Rd
+++ b/Recommended/mgcv/man/gaulss.Rd
@@ -33,7 +33,7 @@ The null deviance reported for this family is the sum of squares of the differen
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 }
 
 

--- a/Recommended/mgcv/man/gevlss.Rd
+++ b/Recommended/mgcv/man/gevlss.Rd
@@ -34,7 +34,7 @@ nonregular cases. Biometrika 72(1):67-90
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/mgcv-package.Rd
+++ b/Recommended/mgcv/man/mgcv-package.Rd
@@ -94,7 +94,7 @@ references to the large literature on which the methods are based.
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models (with discussion).
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 Wood, S.N. (2011) Fast stable restricted maximum likelihood 
 and marginal likelihood estimation of semiparametric generalized linear 

--- a/Recommended/mgcv/man/multinom.Rd
+++ b/Recommended/mgcv/man/multinom.Rd
@@ -34,7 +34,7 @@ Note that the model is not completely invariant to category relabelling, even if
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/mvn.Rd
+++ b/Recommended/mgcv/man/mvn.Rd
@@ -34,7 +34,7 @@ residuals are standardized to be approximately independent standard normal if al
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/negbin.Rd
+++ b/Recommended/mgcv/man/negbin.Rd
@@ -74,7 +74,7 @@ Venables, B. and B.R. Ripley (2002) Modern Applied Statistics in S, Springer.
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/ocat.Rd
+++ b/Recommended/mgcv/man/ocat.Rd
@@ -40,7 +40,7 @@ Rather than remove the intercept, \code{ocat} simply sets the first cut point to
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 }
 
 

--- a/Recommended/mgcv/man/scat.Rd
+++ b/Recommended/mgcv/man/scat.Rd
@@ -38,7 +38,7 @@ random variable have finite variance.
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/ziP.Rd
+++ b/Recommended/mgcv/man/ziP.Rd
@@ -48,7 +48,7 @@ Zero inflated models are often over-used. Having lots of zeroes in the data does
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 
 }
 

--- a/Recommended/mgcv/man/ziplss.Rd
+++ b/Recommended/mgcv/man/ziplss.Rd
@@ -42,7 +42,7 @@ avoid problems. For 1D smooths uses e.g. \code{s(x,m=1)} and for isotropic smoot
 Wood, S.N., N. Pya and B. Saefken (2016), Smoothing parameter and
 model selection for general smooth models.
 Journal of the American Statistical Association 111, 1548-1575
-\url{http://dx.doi.org/10.1080/01621459.2016.1180986}
+\url{https://doi.org/10.1080/01621459.2016.1180986}
 }
 
 \section{WARNINGS }{


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!

PS: If you are using any upstream git repos, where I should suggest these changes as well, please feel free to point me to them.